### PR TITLE
docs: copy editing and fix styles

### DIFF
--- a/www/docs/Button.mdx
+++ b/www/docs/Button.mdx
@@ -6,7 +6,7 @@ import { Button } from "@restart/ui";
 <Button>I'm a Button</Button>;
 ```
 
-Not very impressive on it's own, but `Button` does come with a few conveniences 
+Not very impressive on its own, but `Button` does come with a few conveniences 
 over the plain HTML element.
 
 - `type` defaults to `button`

--- a/www/docs/Button.mdx
+++ b/www/docs/Button.mdx
@@ -6,7 +6,7 @@ import { Button } from "@restart/ui";
 <Button>I'm a Button</Button>;
 ```
 
-Not very impressive on it's own, but `Button` does comes with a few conveniences 
+Not very impressive on it's own, but `Button` does come with a few conveniences 
 over the plain HTML element.
 
 - `type` defaults to `button`

--- a/www/docs/Button.mdx
+++ b/www/docs/Button.mdx
@@ -6,8 +6,8 @@ import { Button } from "@restart/ui";
 <Button>I'm a Button</Button>;
 ```
 
-Not very impressive on it's own, Button comes with a few conveniences over the
-plain HTML element.
+Not very impressive on it's own, but `Button` does comes with a few conveniences 
+over the plain HTML element.
 
 - `type` defaults to `button`
 - Ensures that non `button` `as` options remain accessible
@@ -20,5 +20,34 @@ import { Button } from "@restart/ui";
   <Button>I'm a Button</Button>
   <Button href="/home">I'm a link</Button>
   <Button as="span">I'm a span but also a button</Button>
+</div>;
+```
+
+## Styling
+
+```jsx live
+import { Button } from "@restart/ui";
+import clsx from "clsx";
+
+function StyledButton(props) {
+  return (
+    <Button
+      {...props}
+      className={clsx(
+        props.className,
+        "transition text-md",
+        "h-10 bg-white border border-primary text-primary rounded px-8 mt-4 appearance-none text-center whitespace-no-wrap",
+        "focus:outline-none focus:ring-4 ring-brand-200",
+        !props.disabled && "cursor-pointer hover:bg-primary hover:text-white",
+        "active:bg-brand-600 active:text-white",
+        props.disabled && "cursor-not-allowed opacity-60"
+      )}
+    />
+  );
+}
+
+<div className="space-x-4">
+  <StyledButton>Button</StyledButton>
+  <StyledButton disabled>Disabled</StyledButton>
 </div>;
 ```

--- a/www/docs/Dropdown.mdx
+++ b/www/docs/Dropdown.mdx
@@ -1,14 +1,14 @@
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
 
-`Dropdown` is set of structural components for building, accessible dropdown menus with close-on-click,
-keyboard navigation, and correct focus handling. As with all the react-overlay's
-components it's BYOS (Bring Your Own Styles). Dropdown is primarily
-built from three base components, you should compose to build your Dropdowns.
+`Dropdown` is a set of structural components for building accessible dropdown menus with close-on-click,
+keyboard navigation, and correct focus handling. Like all of `@restart/ui`
+components, it's BYOS (Bring Your Own Styles). `Dropdown` is primarily
+built from three base components that you should compose to build your dropdowns.
 
 - `Dropdown`: wraps the menu and toggle, and handles keyboard navigation
-- `Dropdown.Toggle`: generally a button that triggers the menu opening
-- `Dropdown.Menu`: the overlaid, menu, positioned to the toggle with PopperJS
+- `Dropdown.Toggle`: generally a button that triggers the opening of the menu
+- `Dropdown.Menu`: the overlaid menu, positioned to the toggle with `PopperJS`
 
 ```jsx live
 import clsx from "clsx";
@@ -95,18 +95,18 @@ function DropdownExample() {
 
 ## Components
 
-Dropdowns are made up of a wrapping `Dropdown` components, a `Toggle` that
-triggers that menu visibility, a `Menu` and the `Item`s in that menu. With the exception
-of the outer `Dropdown` component each sub component can be constructed with a component
-render prop API or hook depending on preference.
+Dropdowns are made up of a wrapping `Dropdown` component, a `Toggle` that
+triggers that menu visibility, a `Menu` and the `Item`s within that menu. With the exception
+of the outer `Dropdown` component, each sub component can be constructed with a component
+render prop API or a hook depending on preference.
 
 ### Dropdown
 
-The `Dropdown` component is the non presentational orchestrator of the dropdown state.
-It handles menu visibility, keyboard navigation and focus management. As a convenience a
+The `Dropdown` component is the non-presentational orchestrator of the dropdown state.
+It handles menu visibility, keyboard navigation and focus management. As a convenience, a
 few `Menu` specific props can be provided to `Dropdown` directly, such as `placement`. It
-is sometimes helpful to also render a wrapping DOM element around your Toggle and Menu, but not
-required.
+is sometimes helpful to also render a wrapping DOM element around your `Toggle` and `Menu`, 
+but not it's required.
 
 ```jsx
 import { Dropdown } from '@restart/ui';
@@ -121,8 +121,8 @@ import { Dropdown } from '@restart/ui';
 
 ### Toggle
 
-The `Toggle` is an interactive element, usually a button, that opens the Dropdown Menu.
-The toggle props contain a `ref` that must be passed to a valid DOM element, you
+The `Toggle` is an interactive element (usually a button) that opens the dropdown menu.
+The toggle props contain a `ref` that must be passed to a valid DOM element. You
 can pass `disabled` and `onClick` props as well and they will be composed into the returned
 props automatically.
 
@@ -167,8 +167,8 @@ const MyDropdownToggle = (props) => (
 ### Menu
 
 The dropdown `Menu` provides an overlay that is positioned next to the dropdown toggle.
-Menu's are positioned with PopperJS by default, and accept all configuration options
-available to Popper.
+Menu's are positioned with `PopperJS` by default, and accept all configuration options
+available to `Popper`.
 
 <Tabs
   defaultValue="hook"
@@ -227,14 +227,15 @@ const MyDropdownToggle = (props) => (
 
 ## Implementing show/hide
 
-Because PopperJs must measure the Menu element it's recommended that you style
+Because `PopperJS` must measure the `Menu` element, it's recommended that you style
 the Menu with `opacity: 0` and `visibility: hidden` when not shown.
-This allows popper to calculate the correct offset for the Menu even when it's not visble.
-this also makes it a bit simpler to animate if you desire.
+This allows `Popper` to calculate the correct offset for the `Menu` even when it's not 
+visible. This also makes it a bit simpler to animate if you desire.
 
-When transitioning it's best to use **both** `visibility` and `opacity`. Setting
-`visibility` to `hidden` will remove the menu from keyboard Tab order, but it doesn't transition
-nicely, so adding opacity (or some other visual property) to indicate fade out and in.
+When transitioning, it's best to use **both** `visibility` and `opacity`. Setting
+`visibility` to `hidden` will remove the menu from the keyboard tab order, but it 
+doesn't transition nicely, so add `opacity` (or some other visual property) to 
+indicate fade out and in.
 
 ```jsx live
 import { Dropdown } from "@restart/ui";
@@ -266,7 +267,7 @@ import { Dropdown } from "@restart/ui";
 ```
 
 If the above isn't feasible and you must use `display: none` to hide the menu, you
-may need to manually trigger a position recalculation on show, when popper is able to
+may need to manually trigger a position re-calculation on show when `Popper` is able to
 measure the element.
 
 ```jsx
@@ -294,11 +295,11 @@ function Menu() {
 
 ## Different containers
 
-Dropdowns use `PopperJS` by default to position Menu's to Toggles. PopperJS is a
-powerful positioning library that lets you easily construct Dropdown markup to suit
+Dropdowns use `Popper` by default to position `Menu`s to `Toggle`s. `Popper` is a
+powerful positioning library that lets you easily construct `Dropdown` markup to suit
 your app's needs.
 
-The example here positions the Menu to the `document` body via a Portal.
+The example here positions the `Menu` to the `document` body via a `Portal`.
 
 ```js live
 import { Dropdown } from "@restart/ui";

--- a/www/docs/Modal.mdx
+++ b/www/docs/Modal.mdx
@@ -1,25 +1,30 @@
-Love them or hate them, `<Modal />` provides a solid foundation for creating dialogs, lightboxes, or whatever else.
-The Modal component renders its `children` node in front of a backdrop component.
+Love them or hate them, `<Modal />` provides a solid foundation for creating dialogs, 
+lightboxes, or whatever else. The `Modal` component renders its `children` node in front 
+of a backdrop component.
 
-The Modal offers a few helpful features over using just a `<Portal/>` component and some styles:
+The `Modal` offers a few helpful features over using just a `<Portal/>` component and 
+some styles:
 
 - Manages dialog stacking when one-at-a-time just isn't enough.
-- Creates a backdrop, for disabling interaction below the modal.
-- It properly manages focus; moving to the modal content, and keeping it there until the modal is closed.
-- It disables scrolling of the page content while open.
-- Adds the appropriate ARIA roles are automatically.
-- Easily-pluggable animations via a `<Transition/>` component.
+- Creates a backdrop for disabling interaction below the modal.
+- Properly manages focus; moving to the modal content, and keeping it there until 
+the modal is closed.
+- Disables scrolling of the page content while open.
+- Adds the appropriate ARIA roles automatically.
+- Allows easily-pluggable animations via a `<Transition/>` component.
 
-Note that, in the same way the backdrop element prevents users from clicking or interacting
-with the page content underneath the Modal, screen readers also need to be signaled to not to
-interact with page content while the Modal is open. To do this, we use a common technique of applying
-the `aria-hidden='true'` attribute to the non-Modal elements in the Modal `container`. This means that for
-a Modal to be truly modal, it should have a `container` that is _outside_ your app's
-React hierarchy (such as the default: document.body).
+Note that, in the same way the backdrop element prevents users from clicking or 
+interacting with the page content underneath the `Modal`, screen readers also need to 
+be signaled to not to interact with page content while the `Modal` is open. To do this, 
+we use a common technique of applying the `aria-hidden="true"` attribute to the 
+non-modal elements in the `Modal` `container`. This means that for a `Modal` to be 
+truly modal, it should have a `container` that is _outside_ your app's React hierarchy 
+(such as the default `document.body`).
 
 ```jsx live renderAsComponent
 import styled from "@emotion/styled";
 import { Modal } from "@restart/ui";
+import Button from "../src/Button";
 
 let rand = () => Math.floor(Math.random() * 20) - 10;
 
@@ -55,13 +60,12 @@ function ModalExample() {
 
   return (
     <div className="modal-example">
-      <button
-        type="button"
-        className="btn btn-primary mb-4"
+      <Button
+        className="mb-4"
         onClick={() => setShow(true)}
       >
         Open Modal
-      </button>
+      </Button>
       <p>Click to get the full Modal experience!</p>
 
       <RandomlyPositionedModal

--- a/www/docs/Nav.mdx
+++ b/www/docs/Nav.mdx
@@ -22,11 +22,11 @@ import { Nav, NavItem } from "@restart/ui";
 
 ## Styling
 
-A `NavItem`s implement a few bits of state that likely need visual styling to use.
+`NavItem`s implement a few bits of state that likely need visual styling to use.
 
-- `disabled` whether the navitem is actionable or not
+- `disabled` whether the `NavItem` is actionable or not.
 - `active` whether the nav item is "selected", this may be because the `activeKey`
-  on Nav matches the `NavItem`'s key, or because the `active` prop was passed to it
+  on `Nav` matches the `NavItem`'s key, or because the `active` prop was passed to it.
 
 ```jsx live
 import clsx from "clsx";
@@ -78,7 +78,7 @@ function Example() {
 
 ## Dropdowns
 
-Dropdown components can be used in `Nav`'s as well:
+Dropdown components can be used in `Nav`s as well:
 
 ```jsx live
 import clsx from "clsx";
@@ -154,7 +154,7 @@ function Example() {
 
 ## Tabs
 
-Create dynamic tabbed interfaces from a `Nav`, as described in the WAI ARIA Authoring Practices.
+Create dynamic tabbed interfaces from a `Nav`, as described in the WAI-ARIA Authoring Practices.
 Note that tabbed UIs have specific behavior that sets them apart from a navigation menu, even
 when styled similarly.
 

--- a/www/docs/transitions.mdx
+++ b/www/docs/transitions.mdx
@@ -5,8 +5,8 @@ title: Animation and Transitions
 Animation of components is handled by `transition` props. If
 a component accepts a `transition` prop you can provide
 a [react-transition-group@2.0.0](https://github.com/reactjs/react-transition-group)
-compatible`Transition` component and it will work.Feel free to use `CSSTransition` specifically, or roll your
-own like the below example.
+compatible `Transition` component and it will work. Feel free to use `CSSTransition`
+specifically, or roll your own like the below example.
 
 ```js live
 import { Modal, Overlay } from "@restart/ui";

--- a/www/src/css/tailwind.css
+++ b/www/src/css/tailwind.css
@@ -7,6 +7,7 @@ h3 { font-size: var(--ifm-h3-font-size); }
 h4 { font-size: var(--ifm-h4-font-size); }
 h5 { font-size: var(--ifm-h5-font-size); }
 h6 { font-size: var(--ifm-h6-font-size); }
+ul { @apply list-disc list-inside }
 
 :root {
   --ifm-color-primary: theme('colors.brand.500');


### PR DESCRIPTION
Random copy editing and fix bullet list styling

Not sure what's causing the error for the animations and transitions example

> ChunkLoadError: Loading chunk examples-docs ransitions.mdx failed. (missing: http://localhost:3000/ui/examples-docsransitions.mdx.js)