### PR TITLE
fix(Anchor): fix onKeyDown when href is non-trivial

### DIFF
--- a/src/Anchor.tsx
+++ b/src/Anchor.tsx
@@ -30,7 +30,7 @@ function isTrivialHref(href?: string) {
  * cases where the `href` is missing or trivial are treated like buttons
  */
 const Anchor = React.forwardRef<HTMLAnchorElement, AnchorProps>(
-  ({ onKeyDown, ...props }: AnchorProps, ref) => {
+  ({ onKeyDown, ...props }, ref) => {
     const buttonProps = useButtonProps({ tagName: 'a', ...props });
 
     const handleKeyDown = useEventCallback(
@@ -47,8 +47,8 @@ const Anchor = React.forwardRef<HTMLAnchorElement, AnchorProps>(
       );
     }
 
-    // eslint-disable-next-line jsx-a11y/anchor-has-content
-    return <a ref={ref} {...props} />;
+    // eslint-disable-next-line jsx-a11y/anchor-has-content, jsx-a11y/no-static-element-interactions
+    return <a ref={ref} {...props} onKeyDown={onKeyDown} />;
   },
 );
 

--- a/test/AnchorSpec.js
+++ b/test/AnchorSpec.js
@@ -42,6 +42,16 @@ describe('Anchor', () => {
     handleClick.should.have.been.calledOnce;
   });
 
+  it('should call onKeyDown handler when href is non-trivial', () => {
+    const onKeyDownSpy = sinon.spy();
+
+    shallow(<Anchor href="http://google.com" onKeyDown={onKeyDownSpy} />)
+      .find('a')
+      .simulate('keyDown', { key: ' ', preventDefault() {} });
+
+    onKeyDownSpy.should.have.been.calledOnce;
+  });
+
   it('prevents default when no href is provided', () => {
     const handleClick = sinon.spy();
 


### PR DESCRIPTION
Fixes case where `onKeyDown` wasn't being applied with valid hrefs