### PR TITLE
fix(usePopper): fix Popper modifier validation error

### DIFF
--- a/src/usePopper.ts
+++ b/src/usePopper.ts
@@ -4,7 +4,11 @@ import * as Popper from '@popperjs/core';
 import { dequal } from 'dequal';
 import { createPopper } from './popper';
 
-const disabledApplyStylesModifier = { name: 'applyStyles', enabled: false };
+const disabledApplyStylesModifier = {
+  name: 'applyStyles',
+  enabled: false,
+  phase: 'write',
+};
 
 // until docjs supports type exports...
 export type Modifier<Name, Options> = Popper.Modifier<Name, Options>;


### PR DESCRIPTION
Fixes this error:

Error: Uncaught Error: Popper: modifier "applyStyles" provided an invalid "phase" property, expected either beforeRead, read, afterRead, beforeMain, main, afterMain, beforeWrite, write, afterWrite but got "undefined"