### PR TITLE
fix(Dropdown): avoid calling onToggle if menu hidden

### DIFF
--- a/src/Dropdown.tsx
+++ b/src/Dropdown.tsx
@@ -282,6 +282,10 @@ function Dropdown({
       return;
     }
 
+    if (key === 'Tab' && (!menuRef.current || !show)) {
+      return;
+    }
+
     lastSourceEvent.current = event.type;
     const meta = { originalEvent: event, source: event.type };
     switch (key) {
@@ -312,7 +316,7 @@ function Dropdown({
           (e) => {
             if (
               (e.key === 'Tab' && !e.target) ||
-              !menuRef.current!.contains(e.target as HTMLElement)
+              !menuRef.current?.contains(e.target as HTMLElement)
             ) {
               onToggle(false, meta);
             }

--- a/src/Waypoint.tsx
+++ b/src/Waypoint.tsx
@@ -1,4 +1,4 @@
-import useCallbackRef from '@restart/hooks/useCallbackRef ';
+import useCallbackRef from '@restart/hooks/useCallbackRef';
 import * as React from 'react';
 
 import useWaypoint, {


### PR DESCRIPTION
Port of these 2 fixes from RO:

https://github.com/react-bootstrap/react-overlays/pull/959
https://github.com/react-bootstrap/react-overlays/pull/958

Also fixes import of useCallbackRef in Waypoint - my bad