### PR TITLE
feat(useWayypoint): handle zero dimension or invisible root

### DIFF
--- a/src/useWaypoint.tsx
+++ b/src/useWaypoint.tsx
@@ -43,7 +43,8 @@ export interface WaypointOptions
 }
 
 export enum Position {
-  BEFORE = 1,
+  UNKNOWN = 0
+  BEFORE,
   INSIDE,
   AFTER,
 }
@@ -95,7 +96,7 @@ function useWaypoint(
       const rootStart = entry.rootBounds?.[start] || 0;
       const rootEnd = entry.rootBounds?.[end] || 0;
 
-      let position: Position = Position.INSIDE;
+      let position: Position = Position.UNKNOWN;
       if (entry.isIntersecting) {
         position = Position.INSIDE;
       } else if (coord > rootEnd) {


### PR DESCRIPTION
This covers a few edge cases where the waypoint may not fall into any of the real positions, due to the `root` being invisible or not having dimensions, such as the beginning of a transition of a scrolling container. By having another position, when the root does have a measurable shape it can switch to and fire an event