### PR TITLE
refactor(DropdownItem)!: rename active to isActive in metadata

### DIFF
--- a/src/DropdownItem.tsx
+++ b/src/DropdownItem.tsx
@@ -1,4 +1,3 @@
-import PropTypes from 'prop-types';
 import * as React from 'react';
 import { useContext } from 'react';
 import useEventCallback from '@restart/hooks/useEventCallback';
@@ -11,42 +10,31 @@ import Button from './Button';
 import { dataAttr } from './DataKey';
 
 export interface DropdownItemProps extends React.HTMLAttributes<HTMLElement> {
+  /**
+   * Element used to render the component.
+   */
   as?: React.ElementType;
-  active?: boolean;
-  disabled?: boolean;
-  eventKey?: EventKey;
-  href?: string;
-}
 
-const propTypes = {
   /**
    * Highlight the menu item as active.
    */
-  active: PropTypes.bool,
+  active?: boolean;
 
   /**
    * Disable the menu item, making it unselectable.
    */
-  disabled: PropTypes.bool,
+  disabled?: boolean;
 
   /**
    * Value passed to the `onSelect` handler, useful for identifying the selected menu item.
    */
-  eventKey: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  eventKey?: EventKey;
 
   /**
    * HTML `href` attribute corresponding to `a.href`.
    */
-  href: PropTypes.string,
-
-  /**
-   * Callback fired when the menu item is clicked.
-   */
-  onClick: PropTypes.func,
-
-  /** @default Button */
-  as: PropTypes.elementType,
-};
+  href?: string;
+}
 
 interface UseDropdownItemOptions {
   key?: EventKey | null;
@@ -73,7 +61,7 @@ export function useDropdownItem({
   const { activeKey } = navContext || {};
   const eventKey = makeEventKey(key, href);
 
-  active =
+  const isActive =
     active == null && key != null
       ? makeEventKey(activeKey) === eventKey
       : active;
@@ -92,10 +80,10 @@ export function useDropdownItem({
     {
       onClick: handleClick,
       'aria-disabled': disabled || undefined,
-      'aria-selected': active,
+      'aria-selected': isActive,
       [dataAttr('dropdown-item')]: '',
     },
-    { active },
+    { isActive },
   ] as const;
 }
 
@@ -122,15 +110,10 @@ const DropdownItem: DynamicRefForwardingComponent<
       active,
     });
 
-    return (
-      // "TS2604: JSX element type 'Component' does not have any construct or call signatures."
-      // @ts-ignore
-      <Component {...props} ref={ref} {...dropdownItemProps} />
-    );
+    return <Component {...props} ref={ref} {...dropdownItemProps} />;
   },
 );
 
 DropdownItem.displayName = 'DropdownItem';
-DropdownItem.propTypes = propTypes;
 
 export default DropdownItem;

--- a/test/DropdownItemSpec.tsx
+++ b/test/DropdownItemSpec.tsx
@@ -1,0 +1,63 @@
+import * as React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import sinon from 'sinon';
+
+import DropdownItem from '../src/DropdownItem';
+import SelectableContext from '../src/SelectableContext';
+
+describe('<DropdownItem>', () => {
+  it('should output a nav item as button', () => {
+    const { getByText } = render(<DropdownItem>test</DropdownItem>);
+
+    getByText('test').tagName.should.equal('BUTTON');
+  });
+
+  it('should trigger onClick', () => {
+    const onClickSpy = sinon.spy();
+    const { getByText } = render(
+      <DropdownItem onClick={onClickSpy}>test</DropdownItem>,
+    );
+    fireEvent.click(getByText('test'));
+    onClickSpy.should.be.called;
+  });
+
+  it('should not trigger onClick if disabled', () => {
+    const onClickSpy = sinon.spy();
+    const { getByText } = render(
+      <DropdownItem onClick={onClickSpy} disabled>
+        test
+      </DropdownItem>,
+    );
+    fireEvent.click(getByText('test'));
+    onClickSpy.should.not.be.called;
+  });
+
+  it('should call onSelect if a key is defined', () => {
+    const onSelect = sinon.spy();
+    const { getByText } = render(
+      <SelectableContext.Provider value={onSelect}>
+        <DropdownItem eventKey="abc">test</DropdownItem>
+      </SelectableContext.Provider>,
+    );
+
+    fireEvent.click(getByText('test'));
+    onSelect.should.be.calledWith('abc');
+  });
+
+  it('should not call onSelect onClick stopPropagation called', () => {
+    const onSelect = sinon.spy();
+    const handleClick = (e: React.MouseEvent) => {
+      e.stopPropagation();
+    };
+    const { getByText } = render(
+      <SelectableContext.Provider value={onSelect}>
+        <DropdownItem eventKey="abc" onClick={handleClick}>
+          test
+        </DropdownItem>
+      </SelectableContext.Provider>,
+    );
+
+    fireEvent.click(getByText('test'));
+    onSelect.should.not.be.called;
+  });
+});


### PR DESCRIPTION
BREAKING CHANGE: rename active to isActive in metadata

Minor breaking change so it's consistent with `NavItem` and `TabPanel`