### PR TITLE
fix(Button): allow ElementType for tagName prop

### DIFF
--- a/src/Button.tsx
+++ b/src/Button.tsx
@@ -13,7 +13,7 @@ export interface UseButtonPropsOptions extends AnchorOptions {
   disabled?: boolean;
   onClick?: React.EventHandler<React.MouseEvent | React.KeyboardEvent>;
   tabIndex?: number;
-  tagName?: keyof JSX.IntrinsicElements;
+  tagName?: React.ElementType;
 }
 
 export function isTrivialHref(href?: string) {


### PR DESCRIPTION
Allows custom react components for the `useButtonProps` hook to address part of https://github.com/react-bootstrap/react-bootstrap/issues/6003