### PR TITLE
feat: add support for iframe and differing owner documents

### DIFF
--- a/src/Modal.tsx
+++ b/src/Modal.tsx
@@ -22,6 +22,7 @@ import useEventCallback from '@restart/hooks/useEventCallback';
 import ModalManager from './ModalManager';
 import useWaitForDOMRef, { DOMContainer } from './useWaitForDOMRef';
 import { TransitionCallbacks } from './types';
+import useWindow from './useWindow';
 
 let manager: ModalManager;
 
@@ -172,13 +173,14 @@ export interface ModalProps extends BaseModalProps {
   [other: string]: any;
 }
 
-function getManager() {
-  if (!manager) manager = new ModalManager();
+function getManager(window?: Window) {
+  if (!manager) manager = new ModalManager({ ownerDocument: window?.document });
   return manager;
 }
 
 function useModalManager(provided?: ModalManager) {
-  const modalManager = provided || getManager();
+  const window = useWindow();
+  const modalManager = provided || getManager(window);
 
   const modal = useRef({
     dialog: null as any as HTMLElement,

--- a/src/ModalManager.ts
+++ b/src/ModalManager.ts
@@ -34,7 +34,7 @@ class ModalManager {
 
   protected state!: ContainerState;
 
-  protected ownerDocument: any;
+  protected ownerDocument: Document | undefined;
 
   constructor({
     ownerDocument,

--- a/src/ModalManager.ts
+++ b/src/ModalManager.ts
@@ -8,6 +8,7 @@ export interface ModalInstance {
 }
 
 export interface ModalManagerOptions {
+  ownerDocument?: Document;
   handleContainerOverflow?: boolean;
   isRTL?: boolean;
 }
@@ -31,23 +32,27 @@ class ModalManager {
 
   readonly modals: ModalInstance[];
 
-  private state!: ContainerState;
+  protected state!: ContainerState;
+
+  protected ownerDocument: any;
 
   constructor({
+    ownerDocument,
     handleContainerOverflow = true,
     isRTL = false,
   }: ModalManagerOptions = {}) {
     this.handleContainerOverflow = handleContainerOverflow;
     this.isRTL = isRTL;
     this.modals = [];
+    this.ownerDocument = ownerDocument;
   }
 
   getScrollbarWidth() {
-    return getBodyScrollbarWidth();
+    return getBodyScrollbarWidth(this.ownerDocument);
   }
 
   getElement() {
-    return document.body;
+    return (this.ownerDocument || document).body;
   }
 
   setModalAttributes(_modal: ModalInstance) {

--- a/src/getScrollbarWidth.ts
+++ b/src/getScrollbarWidth.ts
@@ -1,6 +1,10 @@
 /**
  * Get the width of the vertical window scrollbar if it's visible
  */
-export default function getBodyScrollbarWidth() {
-  return Math.abs(window.innerWidth - document.documentElement.clientWidth);
+export default function getBodyScrollbarWidth(ownerDocument = document) {
+  const window = ownerDocument.defaultView!;
+
+  return Math.abs(
+    window.innerWidth - ownerDocument.documentElement.clientWidth,
+  );
 }

--- a/src/useRootClose.ts
+++ b/src/useRootClose.ts
@@ -85,11 +85,11 @@ function useRootClose(
   useEffect(() => {
     if (disabled || ref == null) return undefined;
 
+    const doc = ownerDocument(getRefTarget(ref)!);
+
     // Store the current event to avoid triggering handlers immediately
     // https://github.com/facebook/react/issues/20074
-    let currentEvent = window.event;
-
-    const doc = ownerDocument(getRefTarget(ref)!);
+    let currentEvent = (doc.defaultView || window).event;
 
     // Use capture for this listener so it fires before React's listener, to
     // avoid false positives in the contains() check below if the target DOM
@@ -139,6 +139,7 @@ function useRootClose(
     handleMouseCapture,
     handleMouse,
     handleKeyUp,
+    window,
   ]);
 }
 

--- a/src/useWaitForDOMRef.ts
+++ b/src/useWaitForDOMRef.ts
@@ -1,5 +1,7 @@
 import ownerDocument from 'dom-helpers/ownerDocument';
+import canUseDOM from 'dom-helpers/canUseDOM';
 import { useState, useEffect } from 'react';
+import useWindow from './useWindow';
 
 export type DOMContainer<T extends HTMLElement = HTMLElement> =
   | T
@@ -9,9 +11,10 @@ export type DOMContainer<T extends HTMLElement = HTMLElement> =
 
 export const resolveContainerRef = <T extends HTMLElement>(
   ref: DOMContainer<T> | undefined,
+  document?: Document,
 ): T | HTMLBodyElement | null => {
-  if (typeof document === 'undefined') return null;
-  if (ref == null) return ownerDocument().body as HTMLBodyElement;
+  if (!canUseDOM) return null;
+  if (ref == null) return (document || ownerDocument()).body as HTMLBodyElement;
   if (typeof ref === 'function') ref = ref();
 
   if (ref && 'current' in ref) ref = ref.current;
@@ -24,7 +27,10 @@ export default function useWaitForDOMRef<T extends HTMLElement = HTMLElement>(
   ref: DOMContainer<T> | undefined,
   onResolved?: (element: T | HTMLBodyElement) => void,
 ) {
-  const [resolvedRef, setRef] = useState(() => resolveContainerRef(ref));
+  const window = useWindow();
+  const [resolvedRef, setRef] = useState(() =>
+    resolveContainerRef(ref, window?.document),
+  );
 
   if (!resolvedRef) {
     const earlyRef = resolveContainerRef(ref);

--- a/src/useWindow.ts
+++ b/src/useWindow.ts
@@ -1,0 +1,16 @@
+import { createContext, useContext } from 'react';
+import canUseDOM from 'dom-helpers/canUseDOM';
+
+const Context = createContext(canUseDOM ? window : undefined);
+
+export const Provider = Context.Provider;
+
+/**
+ * The document "window" placed in React context. Helpful for determining
+ * SSR context, or when rendering into an iframe.
+ *
+ * @returns the current window
+ */
+export default function useWindow() {
+  return useContext(Context);
+}

--- a/src/useWindow.ts
+++ b/src/useWindow.ts
@@ -3,7 +3,7 @@ import canUseDOM from 'dom-helpers/canUseDOM';
 
 const Context = createContext(canUseDOM ? window : undefined);
 
-export const Provider = Context.Provider;
+export const WindowProvider = Context.Provider;
 
 /**
  * The document "window" placed in React context. Helpful for determining

--- a/www/docs/useWindow.mdx
+++ b/www/docs/useWindow.mdx
@@ -21,7 +21,7 @@ It's also useful for situations where components are rendered into an `iframe` a
 to target window, not the one they originate from.
 
 ```tsx
-import { Provider as WindowProvider } from "useWindow";
+import { WindowProvider } from "useWindow";
 
 function Iframe({
   children,

--- a/www/docs/useWindow.mdx
+++ b/www/docs/useWindow.mdx
@@ -1,0 +1,47 @@
+A hook that returns the current DOM window. Generally this is the same as the global
+`window` value, except in an SSR context it will return undefined, saving you a `typeof window === 'undefined'` guard.
+
+```tsx
+import useWindow from "@restart/ui/useWindow";
+
+function Widget() {
+  const window = useWindow();
+
+  return (
+    <>
+      <Button>Click me</Button>
+      {window &&
+        createPortal(<Tooltip />, window.document.body)}
+    </>
+  );
+}
+```
+
+It's also useful for situations where components are rendered into an `iframe` and need a reference
+to target window, not the one they originate from.
+
+```tsx
+import { Provider as WindowProvider } from "useWindow";
+
+function Iframe({
+  children,
+  ...props
+}: React.ComponentPropsWithoutRef<"iframe">) {
+  const [contentRef, setContentRef] = React.useState(null);
+  const mountNode = contentRef?.contentWindow.document.body;
+
+  return (
+    <>
+      <iframe {...props} ref={setContentRef} />
+
+      {mountNode &&
+        createPortal(
+          <WindowProvider value={contentRef?.contentWindow}>
+            {children}
+          </WindowProvider>,
+          mountNode
+        )}
+    </>
+  );
+}
+```

--- a/www/sidebars.js
+++ b/www/sidebars.js
@@ -20,7 +20,7 @@ module.exports = {
       type: 'category',
       label: 'Utilities',
       collapsed: false,
-      items: ['usePopper', 'useRootClose'],
+      items: ['usePopper', 'useRootClose', 'useWindow'],
     },
 
     'transitions',


### PR DESCRIPTION
This does a few things:

- Add a `useWindow` hook for accessing the current `window` object, which can be set in unique situations, such as rendering components into an iframe. Defaults the the global `window` if available
- Update references to global document, or window objects to use `useWindow` or if an element is present, their owner document/view