### PR TITLE
fix(NavItem): do not include aria-controls if the related element is not mounted

### DIFF
--- a/src/NavItem.tsx
+++ b/src/NavItem.tsx
@@ -74,7 +74,16 @@ export function useNavItem({
     isActive =
       active == null && key != null ? navContext.activeKey === key : active;
 
-    if (!tabContext?.unmountOnExit || isActive)
+    /**
+     * Simplified scenario for `mountOnEnter`.
+     *
+     * While it would make sense to keep 'aria-controls' for tabs that have been mounted at least
+     * once, it would also complicate the code quite a bit, for very little gain.
+     * The following implementation is probably good enough.
+     *
+     * @see https://github.com/react-restart/ui/pull/40#issuecomment-1009971561
+     */
+    if (isActive || (!tabContext?.unmountOnExit && !tabContext?.mountOnEnter))
       props['aria-controls'] = contextControlledId;
   }
 

--- a/src/NavItem.tsx
+++ b/src/NavItem.tsx
@@ -7,6 +7,7 @@ import SelectableContext, { makeEventKey } from './SelectableContext';
 import { EventKey, DynamicRefForwardingComponent } from './types';
 import Button from './Button';
 import { dataAttr } from './DataKey';
+import TabContext from './TabContext';
 
 export interface NavItemProps extends React.HTMLAttributes<HTMLElement> {
   /**
@@ -54,6 +55,7 @@ export function useNavItem({
 }: UseNavItemOptions) {
   const parentOnSelect = useContext(SelectableContext);
   const navContext = useContext(NavContext);
+  const tabContext = useContext(TabContext);
 
   let isActive = active;
   const props = { role } as any;
@@ -68,10 +70,12 @@ export function useNavItem({
     props[dataAttr('event-key')] = key;
 
     props.id = contextControllerId || id;
-    props['aria-controls'] = contextControlledId;
 
     isActive =
       active == null && key != null ? navContext.activeKey === key : active;
+
+    if (!tabContext?.unmountOnExit || isActive)
+      props['aria-controls'] = contextControlledId;
   }
 
   if (props.role === 'tab') {

--- a/test/ModalSpec.js
+++ b/test/ModalSpec.js
@@ -336,7 +336,7 @@ describe('<Modal>', () => {
     );
   });
 
-  xdescribe('Focused state', () => {
+  describe('Focused state', () => {
     let focusableContainer = null;
 
     beforeEach(() => {

--- a/test/TabContainerSpec.tsx
+++ b/test/TabContainerSpec.tsx
@@ -160,6 +160,27 @@ describe('<Tabs>', () => {
     expect(queryByText('Tab 2')).to.exist;
   });
 
+  it('Should include "aria-controls" matching rendered TabPanel', () => {
+    const { queryByText, getByText } = render(
+      <Tabs defaultActiveKey={1}>
+        <Nav>
+          <NavItem eventKey="1">One</NavItem>
+
+          <NavItem eventKey="2">Two</NavItem>
+        </Nav>
+        <div>
+          <TabPanel eventKey="1">Tab 1</TabPanel>
+          <TabPanel eventKey="2">Tab 2</TabPanel>
+        </div>
+      </Tabs>,
+    );
+
+    expect(queryByText('Tab 1')).to.exist;
+    expect(queryByText('Tab 2')).to.exist;
+    expect(getByText('One').getAttribute('aria-controls')).to.exist;
+    expect(getByText('Two').getAttribute('aria-controls')).to.exist;
+  });
+
   it('Should include "aria-controls" only for rendered tabs when unmountOnExit is true', () => {
     const { queryByText, getByText } = render(
       <Tabs unmountOnExit defaultActiveKey={1}>
@@ -181,6 +202,31 @@ describe('<Tabs>', () => {
     expect(getByText('Two').getAttribute('aria-controls')).to.not.exist;
     fireEvent.click(getByText('Two'));
     expect(queryByText('Tab 1')).to.not.exist;
+    expect(queryByText('Tab 2')).to.exist;
+    expect(getByText('One').getAttribute('aria-controls')).to.not.exist;
+    expect(getByText('Two').getAttribute('aria-controls')).to.exist;
+  });
+
+  it('Should include "aria-controls" only for the active tab, when mountOnEnter is true', () => {
+    const { queryByText, getByText } = render(
+      <Tabs mountOnEnter defaultActiveKey={1}>
+        <Nav>
+          <NavItem eventKey="1">One</NavItem>
+
+          <NavItem eventKey="2">Two</NavItem>
+        </Nav>
+        <div>
+          <TabPanel eventKey="1">Tab 1</TabPanel>
+          <TabPanel eventKey="2">Tab 2</TabPanel>
+        </div>
+      </Tabs>,
+    );
+    expect(queryByText('Tab 1')).to.exist;
+    expect(queryByText('Tab 2')).to.not.exist;
+    expect(getByText('One').getAttribute('aria-controls')).to.exist;
+    expect(getByText('Two').getAttribute('aria-controls')).to.not.exist;
+    fireEvent.click(getByText('Two'));
+    expect(queryByText('Tab 1')).to.exist;
     expect(queryByText('Tab 2')).to.exist;
     expect(getByText('One').getAttribute('aria-controls')).to.not.exist;
     expect(getByText('Two').getAttribute('aria-controls')).to.exist;

--- a/test/TabContainerSpec.tsx
+++ b/test/TabContainerSpec.tsx
@@ -159,4 +159,30 @@ describe('<Tabs>', () => {
     expect(queryByText('Tab 1')).to.not.exist;
     expect(queryByText('Tab 2')).to.exist;
   });
+
+  it('Should include "aria-controls" only for rendered tabs when unmountOnExit is true', () => {
+    const { queryByText, getByText } = render(
+      <Tabs unmountOnExit defaultActiveKey={1}>
+        <Nav>
+          <NavItem eventKey="1">One</NavItem>
+
+          <NavItem eventKey="2">Two</NavItem>
+        </Nav>
+        <div>
+          <TabPanel eventKey="1">Tab 1</TabPanel>
+          <TabPanel eventKey="2">Tab 2</TabPanel>
+        </div>
+      </Tabs>,
+    );
+
+    expect(queryByText('Tab 1')).to.exist;
+    expect(queryByText('Tab 2')).to.not.exist;
+    expect(getByText('One').getAttribute('aria-controls')).to.exist;
+    expect(getByText('Two').getAttribute('aria-controls')).to.not.exist;
+    fireEvent.click(getByText('Two'));
+    expect(queryByText('Tab 1')).to.not.exist;
+    expect(queryByText('Tab 2')).to.exist;
+    expect(getByText('One').getAttribute('aria-controls')).to.not.exist;
+    expect(getByText('Two').getAttribute('aria-controls')).to.exist;
+  });
 });


### PR DESCRIPTION
When using a `TabContainer` with `unmountOnExit = true` or `mountOnEnter = true`, this PR will remove `aria-controls` attribute from all the `NavItem` that are not active.

Right now the `aria-controls` would be pointing to elements that are not rendered on the page.
This can be an issue, and is usually marked as so by some development tools focused on a11y.

## This PR also:

1. converts `TabContainerSpec` to use @testing-library/react
2. re-enables 'Focused state' tests for ModalSpec — were these disabled for a specific reason? They are all passing.