### PR TITLE
Fix `transitions` code playground and use Tooltip component

### DIFF
--- a/www/docs/Overlay.mdx
+++ b/www/docs/Overlay.mdx
@@ -14,6 +14,7 @@ positioning engine.
 import clsx from "clsx";
 import { Overlay } from "@restart/ui";
 import Button from "../src/Button";
+import Tooltip from "../src/Tooltip";
 
 const PLACEMENTS = ["left", "top", "right", "bottom"];
 
@@ -70,24 +71,10 @@ function OverlayExample() {
         target={triggerRef}
       >
         {(props, { arrowProps, popper, show }) => (
-          <div {...props} className="absolute">
-            <div
-              {...arrowProps}
-              style={arrowProps.style}
-              className={clsx(
-                "absolute w-3 h-3 z-[-1]",
-                "before:absolute before:rotate-45 before:bg-black before:top-0 before:left-0 before:w-3 before:h-3",
-                popper.placement === "left" && "-right-1",
-                popper.placement === "right" && "-left-1",
-                popper.placement === "bottom" && "-top-1",
-                popper.placement === "top" && "-bottom-1"
-              )}
-            />
-            <div className="py-1 px-2 text-center rounded bg-black text-white ">
-              I&rsquo;m placed to the{" "}
-              <strong>{popper.placement}</strong>
-            </div>
-          </div>
+          <Tooltip {...props} arrowProps={arrowProps} popper={popper}>
+            I&rsquo;m placed to the{" "}
+            <strong>{popper.placement}</strong>
+          </Tooltip>
         )}
       </Overlay>
     </div>

--- a/www/docs/transitions.mdx
+++ b/www/docs/transitions.mdx
@@ -11,35 +11,9 @@ specifically, or roll your own like the below example.
 ```js live
 import { Modal, Overlay } from "@restart/ui";
 import Transition from "react-transition-group/Transition";
+import '../src/css/transitions.css';
 
 const FADE_DURATION = 200;
-
-injectCss(`
-  .fade {
-    opacity: 0;
-    transition: opacity ${FADE_DURATION}ms linear;
-  }
-
-  .show {
-    opacity: 1;
-  }
-
-
-  .backdrop.fade.show {
-    opacity: 0.5;
-  }
-
-  .dialog {
-    position: absolute;
-    width: 400;
-    top: 50%; left: 50%;
-    transform: translate(-50%, -50%);
-    border: 1px solid #e5e5e5;
-    background-color: white;
-    box-shadow: 0 5px 15px rgba(0, 0, 0, .5);
-    padding: 20px;
-  }
-`);
 
 const fadeStyles = {
   entering: "show",
@@ -51,6 +25,10 @@ const Fade = ({ children, ...props }) => (
     {(status, innerProps) =>
       React.cloneElement(children, {
         ...innerProps,
+        style: {
+          transition: `opacity ${FADE_DURATION}ms linear`,
+          ...innerProps.style,
+        },
         className: `fade ${fadeStyles[status]} ${children.props.className}`,
       })
     }
@@ -123,7 +101,7 @@ function TransitionExample() {
             {...props}
             className="fixed inset-0 z-50 flex items-center justify-center pointer-events-none"
           >
-            <div className="dialog bg-white shadow rounded-lg pointer-events-auto">
+            <div className="dialog dialog-transitions-example bg-white shadow rounded-lg pointer-events-auto">
               <h4 id="modal-label">I&apos;m fading in!</h4>
               <p>
                 Anim pariatur cliche reprehenderit, enim

--- a/www/docs/transitions.mdx
+++ b/www/docs/transitions.mdx
@@ -10,7 +10,9 @@ specifically, or roll your own like the below example.
 
 ```js live
 import { Modal, Overlay } from "@restart/ui";
+import clsx from "clsx";
 import Transition from "react-transition-group/Transition";
+import Button from "../src/Button";
 import '../src/css/transitions.css';
 
 const FADE_DURATION = 200;
@@ -25,10 +27,6 @@ const Fade = ({ children, ...props }) => (
     {(status, innerProps) =>
       React.cloneElement(children, {
         ...innerProps,
-        style: {
-          transition: `opacity ${FADE_DURATION}ms linear`,
-          ...innerProps.style,
-        },
         className: `fade ${fadeStyles[status]} ${children.props.className}`,
       })
     }
@@ -38,32 +36,33 @@ const Fade = ({ children, ...props }) => (
 function TransitionExample() {
   const [showModal, setShowModal] = useState(false);
   const [showTooltip, setShowTooltip] = useState(false);
-  const [tooltipRef, attachRef] = useState(null);
+
+  const triggerRef = useRef(null);
 
   return (
     <div className="flex flex-col items-center">
-      <button
+      <Button
         type="button"
         className="btn btn-primary mr-3"
         onClick={() => setShowModal((prev) => !prev)}
       >
         Show Animated Modal
-      </button>
+      </Button>
 
-      <button
+      <Button
         type="button"
         className="btn btn-primary"
         onClick={() => setShowTooltip((prev) => !prev)}
-        ref={attachRef}
+        ref={triggerRef}
       >
         Show Tooltip
-      </button>
+      </Button>
 
       <Overlay
         placement="top"
         transition={Fade}
         show={showTooltip}
-        target={tooltipRef}
+        target={triggerRef}
         popperConfig={{
           modifiers: [
             {
@@ -74,13 +73,24 @@ function TransitionExample() {
           ],
         }}
       >
-        {({ props: { ref, style } }) => (
-          <div
-            ref={ref}
-            className="bg-primary-200 shadow rounded z-10 px-4"
-            style={style}
-          >
-            Hello there
+        {(props, { arrowProps, popper, show }) => (
+          <div {...props} className="absolute">
+            <div
+              {...arrowProps}
+              style={arrowProps.style}
+              className={clsx(
+                "absolute w-3 h-3 z-[-1]",
+                "before:absolute before:rotate-45 before:bg-black before:top-0 before:left-0 before:w-3 before:h-3",
+                popper.placement === "left" && "-right-1",
+                popper.placement === "right" && "-left-1",
+                popper.placement === "bottom" && "-top-1",
+                popper.placement === "top" && "-bottom-1"
+              )}
+            />
+            <div className="py-1 px-2 text-center rounded bg-black text-white ">
+              I&rsquo;m placed to the{" "}
+              <strong>{popper.placement}</strong>
+            </div>
           </div>
         )}
       </Overlay>

--- a/www/docs/transitions.mdx
+++ b/www/docs/transitions.mdx
@@ -10,9 +10,9 @@ specifically, or roll your own like the below example.
 
 ```js live
 import { Modal, Overlay } from "@restart/ui";
-import clsx from "clsx";
 import Transition from "react-transition-group/Transition";
 import Button from "../src/Button";
+import Tooltip from "../src/Tooltip";
 import '../src/css/transitions.css';
 
 const FADE_DURATION = 200;
@@ -74,24 +74,9 @@ function TransitionExample() {
         }}
       >
         {(props, { arrowProps, popper, show }) => (
-          <div {...props} className="absolute">
-            <div
-              {...arrowProps}
-              style={arrowProps.style}
-              className={clsx(
-                "absolute w-3 h-3 z-[-1]",
-                "before:absolute before:rotate-45 before:bg-black before:top-0 before:left-0 before:w-3 before:h-3",
-                popper.placement === "left" && "-right-1",
-                popper.placement === "right" && "-left-1",
-                popper.placement === "bottom" && "-top-1",
-                popper.placement === "top" && "-bottom-1"
-              )}
-            />
-            <div className="py-1 px-2 text-center rounded bg-black text-white ">
-              I&rsquo;m placed to the{" "}
-              <strong>{popper.placement}</strong>
-            </div>
-          </div>
+          <Tooltip {...props} arrowProps={arrowProps} popper={popper}>
+            Tooltip content
+          </Tooltip>
         )}
       </Overlay>
 

--- a/www/src/css/transitions.css
+++ b/www/src/css/transitions.css
@@ -1,0 +1,22 @@
+.fade {
+  opacity: 0;
+  transition: opacity 200ms linear;
+}
+
+.show {
+  opacity: 1;
+}
+
+.backdrop.fade.show {
+  opacity: 0.5;
+}
+
+.dialog-transitions-example {
+  position: absolute;
+  top: 50%; left: 50%;
+  transform: translate(-50%, -50%);
+  border: 1px solid #e5e5e5;
+  background-color: white;
+  box-shadow: 0 5px 15px rgba(0, 0, 0, .5);
+  padding: 20px;
+}


### PR DESCRIPTION
This PR contains the following changes:

- Fix #41
  - fix code playground
  - fix tooltip example (change children props)
-  Use Tooltip component on `Overlay` and `transitions` examples