### PR TITLE
Fix dropdown close

### DIFF
--- a/src/Dropdown.tsx
+++ b/src/Dropdown.tsx
@@ -273,7 +273,12 @@ function Dropdown({
       // Second only to https://github.com/twbs/bootstrap/blob/8cfbf6933b8a0146ac3fbc369f19e520bd1ebdac/js/src/dropdown.js#L400
       // in inscrutability
       const isInput = /input|textarea/i.test(target.tagName);
-      if (isInput && (key === ' ' || (key !== 'Escape' && fromMenu))) {
+      if (
+        isInput &&
+        (key === ' ' ||
+          (key !== 'Escape' && fromMenu) ||
+          (key === 'Escape' && (target as HTMLInputElement).type === 'search'))
+      ) {
         return;
       }
 

--- a/src/DropdownMenu.tsx
+++ b/src/DropdownMenu.tsx
@@ -8,7 +8,7 @@ import usePopper, {
   Offset,
   UsePopperState,
 } from './usePopper';
-import useRootClose, { RootCloseOptions } from './useRootClose';
+import useClickOutside, { ClickOutsideOptions } from './useClickOutside';
 import mergeOptionsWithPopperConfig from './mergeOptionsWithPopperConfig';
 
 export interface UseDropdownMenuOptions {
@@ -61,7 +61,7 @@ export interface UseDropdownMenuOptions {
   /**
    * Override the default event used by RootCloseWrapper.
    */
-  rootCloseEvent?: RootCloseOptions['clickTrigger'];
+  rootCloseEvent?: ClickOutsideOptions['clickTrigger'];
 
   /**
    * A set of popper options and props passed directly to react-popper's Popper component.
@@ -168,7 +168,7 @@ export function useDropdownMenu(options: UseDropdownMenuOptions = {}) {
       : {},
   };
 
-  useRootClose(menuElement, handleClose, {
+  useClickOutside(menuElement, handleClose, {
     clickTrigger: rootCloseEvent,
     disabled: !show,
   });

--- a/src/useClickOutside.ts
+++ b/src/useClickOutside.ts
@@ -32,23 +32,21 @@ export interface ClickOutsideOptions {
 }
 
 /**
- * The `useRootClose` hook registers your callback on the document
- * when rendered. Powers the `<Overlay/>` component. This is used achieve modal
- * style behavior where your callback is triggered when the user tries to
- * interact with the rest of the document or hits the `esc` key.
+ * The `useClickOutside` hook registers your callback on the document that fires
+ * when a pointer event is registered outside of the provided ref or element.
  *
  * @param {Ref<HTMLElement>| HTMLElement} ref  The element boundary
- * @param {function} onRootClose
+ * @param {function} onClickOutside
  * @param {object=}  options
  * @param {boolean=} options.disabled
  * @param {string=}  options.clickTrigger The DOM event name (click, mousedown, etc) to attach listeners on
  */
-function useRootClose(
+function useClickOutside(
   ref: React.RefObject<Element> | Element | null | undefined,
   onClickOutside: (e: Event) => void = noop,
   { disabled, clickTrigger = 'click' }: ClickOutsideOptions = {},
 ) {
-  const preventMouseRootCloseRef = useRef(false);
+  const preventMouseClickOutsideRef = useRef(false);
 
   const handleMouseCapture = useCallback(
     (e) => {
@@ -60,7 +58,7 @@ function useRootClose(
           'useClickOutside(), should be passed a ref that resolves to a DOM node',
       );
 
-      preventMouseRootCloseRef.current =
+      preventMouseClickOutsideRef.current =
         !currentTarget ||
         isModifiedEvent(e) ||
         !isLeftClickEvent(e) ||
@@ -70,7 +68,7 @@ function useRootClose(
   );
 
   const handleMouse = useEventCallback((e: MouseEvent) => {
-    if (!preventMouseRootCloseRef.current) {
+    if (!preventMouseClickOutsideRef.current) {
       onClickOutside(e);
     }
   });
@@ -118,4 +116,4 @@ function useRootClose(
   }, [ref, disabled, clickTrigger, handleMouseCapture, handleMouse]);
 }
 
-export default useRootClose;
+export default useClickOutside;

--- a/src/useClickOutside.ts
+++ b/src/useClickOutside.ts
@@ -1,0 +1,121 @@
+import contains from 'dom-helpers/contains';
+import listen from 'dom-helpers/listen';
+import ownerDocument from 'dom-helpers/ownerDocument';
+import { useCallback, useEffect, useRef } from 'react';
+
+import useEventCallback from '@restart/hooks/useEventCallback';
+import warning from 'warning';
+
+const noop = () => {};
+
+export type MouseEvents = {
+  [K in keyof GlobalEventHandlersEventMap]: GlobalEventHandlersEventMap[K] extends MouseEvent
+    ? K
+    : never;
+}[keyof GlobalEventHandlersEventMap];
+
+function isLeftClickEvent(event: MouseEvent) {
+  return event.button === 0;
+}
+
+function isModifiedEvent(event: MouseEvent) {
+  return !!(event.metaKey || event.altKey || event.ctrlKey || event.shiftKey);
+}
+
+export const getRefTarget = (
+  ref: React.RefObject<Element> | Element | null | undefined,
+) => ref && ('current' in ref ? ref.current : ref);
+
+export interface ClickOutsideOptions {
+  disabled?: boolean;
+  clickTrigger?: MouseEvents;
+}
+
+/**
+ * The `useRootClose` hook registers your callback on the document
+ * when rendered. Powers the `<Overlay/>` component. This is used achieve modal
+ * style behavior where your callback is triggered when the user tries to
+ * interact with the rest of the document or hits the `esc` key.
+ *
+ * @param {Ref<HTMLElement>| HTMLElement} ref  The element boundary
+ * @param {function} onRootClose
+ * @param {object=}  options
+ * @param {boolean=} options.disabled
+ * @param {string=}  options.clickTrigger The DOM event name (click, mousedown, etc) to attach listeners on
+ */
+function useRootClose(
+  ref: React.RefObject<Element> | Element | null | undefined,
+  onClickOutside: (e: Event) => void = noop,
+  { disabled, clickTrigger = 'click' }: ClickOutsideOptions = {},
+) {
+  const preventMouseRootCloseRef = useRef(false);
+
+  const handleMouseCapture = useCallback(
+    (e) => {
+      const currentTarget = getRefTarget(ref);
+
+      warning(
+        !!currentTarget,
+        'ClickOutside captured a close event but does not have a ref to compare it to. ' +
+          'useClickOutside(), should be passed a ref that resolves to a DOM node',
+      );
+
+      preventMouseRootCloseRef.current =
+        !currentTarget ||
+        isModifiedEvent(e) ||
+        !isLeftClickEvent(e) ||
+        !!contains(currentTarget, e.target);
+    },
+    [ref],
+  );
+
+  const handleMouse = useEventCallback((e: MouseEvent) => {
+    if (!preventMouseRootCloseRef.current) {
+      onClickOutside(e);
+    }
+  });
+
+  useEffect(() => {
+    if (disabled || ref == null) return undefined;
+
+    const doc = ownerDocument(getRefTarget(ref)!);
+
+    // Store the current event to avoid triggering handlers immediately
+    // https://github.com/facebook/react/issues/20074
+    let currentEvent = (doc.defaultView || window).event;
+
+    // Use capture for this listener so it fires before React's listener, to
+    // avoid false positives in the contains() check below if the target DOM
+    // element is removed in the React mouse callback.
+    const removeMouseCaptureListener = listen(
+      doc as any,
+      clickTrigger,
+      handleMouseCapture,
+      true,
+    );
+
+    const removeMouseListener = listen(doc as any, clickTrigger, (e) => {
+      // skip if this event is the same as the one running when we added the handlers
+      if (e === currentEvent) {
+        currentEvent = undefined;
+        return;
+      }
+      handleMouse(e);
+    });
+
+    let mobileSafariHackListeners = [] as Array<() => void>;
+    if ('ontouchstart' in doc.documentElement) {
+      mobileSafariHackListeners = [].slice
+        .call(doc.body.children)
+        .map((el) => listen(el, 'mousemove', noop));
+    }
+
+    return () => {
+      removeMouseCaptureListener();
+      removeMouseListener();
+      mobileSafariHackListeners.forEach((remove) => remove());
+    };
+  }, [ref, disabled, clickTrigger, handleMouseCapture, handleMouse]);
+}
+
+export default useRootClose;

--- a/src/useRootClose.ts
+++ b/src/useRootClose.ts
@@ -1,36 +1,20 @@
-import contains from 'dom-helpers/contains';
 import listen from 'dom-helpers/listen';
 import ownerDocument from 'dom-helpers/ownerDocument';
-import { useCallback, useEffect, useRef } from 'react';
+import { useEffect } from 'react';
 
 import useEventCallback from '@restart/hooks/useEventCallback';
-import warning from 'warning';
+import useClickOutside, {
+  ClickOutsideOptions,
+  getRefTarget,
+} from './useClickOutside';
 
 const escapeKeyCode = 27;
 const noop = () => {};
 
-export type MouseEvents = {
-  [K in keyof GlobalEventHandlersEventMap]: GlobalEventHandlersEventMap[K] extends MouseEvent
-    ? K
-    : never;
-}[keyof GlobalEventHandlersEventMap];
-
-function isLeftClickEvent(event: MouseEvent) {
-  return event.button === 0;
-}
-
-function isModifiedEvent(event: MouseEvent) {
-  return !!(event.metaKey || event.altKey || event.ctrlKey || event.shiftKey);
-}
-
-const getRefTarget = (
-  ref: React.RefObject<Element> | Element | null | undefined,
-) => ref && ('current' in ref ? ref.current : ref);
-
-export interface RootCloseOptions {
+export interface RootCloseOptions extends ClickOutsideOptions {
   disabled?: boolean;
-  clickTrigger?: MouseEvents;
 }
+
 /**
  * The `useRootClose` hook registers your callback on the document
  * when rendered. Powers the `<Overlay/>` component. This is used achieve modal
@@ -46,35 +30,11 @@ export interface RootCloseOptions {
 function useRootClose(
   ref: React.RefObject<Element> | Element | null | undefined,
   onRootClose: (e: Event) => void,
-  { disabled, clickTrigger = 'click' }: RootCloseOptions = {},
+  { disabled, clickTrigger }: RootCloseOptions = {},
 ) {
-  const preventMouseRootCloseRef = useRef(false);
   const onClose = onRootClose || noop;
 
-  const handleMouseCapture = useCallback(
-    (e) => {
-      const currentTarget = getRefTarget(ref);
-
-      warning(
-        !!currentTarget,
-        'RootClose captured a close event but does not have a ref to compare it to. ' +
-          'useRootClose(), should be passed a ref that resolves to a DOM node',
-      );
-
-      preventMouseRootCloseRef.current =
-        !currentTarget ||
-        isModifiedEvent(e) ||
-        !isLeftClickEvent(e) ||
-        !!contains(currentTarget, e.target);
-    },
-    [ref],
-  );
-
-  const handleMouse = useEventCallback((e: MouseEvent) => {
-    if (!preventMouseRootCloseRef.current) {
-      onClose(e);
-    }
-  });
+  useClickOutside(ref, onClose, { disabled, clickTrigger });
 
   const handleKeyUp = useEventCallback((e: KeyboardEvent) => {
     if (e.keyCode === escapeKeyCode) {
@@ -91,25 +51,6 @@ function useRootClose(
     // https://github.com/facebook/react/issues/20074
     let currentEvent = (doc.defaultView || window).event;
 
-    // Use capture for this listener so it fires before React's listener, to
-    // avoid false positives in the contains() check below if the target DOM
-    // element is removed in the React mouse callback.
-    const removeMouseCaptureListener = listen(
-      doc as any,
-      clickTrigger,
-      handleMouseCapture,
-      true,
-    );
-
-    const removeMouseListener = listen(doc as any, clickTrigger, (e) => {
-      // skip if this event is the same as the one running when we added the handlers
-      if (e === currentEvent) {
-        currentEvent = undefined;
-        return;
-      }
-      handleMouse(e);
-    });
-
     const removeKeyupListener = listen(doc as any, 'keyup', (e) => {
       // skip if this event is the same as the one running when we added the handlers
       if (e === currentEvent) {
@@ -119,27 +60,10 @@ function useRootClose(
       handleKeyUp(e);
     });
 
-    let mobileSafariHackListeners = [] as Array<() => void>;
-    if ('ontouchstart' in doc.documentElement) {
-      mobileSafariHackListeners = [].slice
-        .call(doc.body.children)
-        .map((el) => listen(el, 'mousemove', noop));
-    }
-
     return () => {
-      removeMouseCaptureListener();
-      removeMouseListener();
       removeKeyupListener();
-      mobileSafariHackListeners.forEach((remove) => remove());
     };
-  }, [
-    ref,
-    disabled,
-    clickTrigger,
-    handleMouseCapture,
-    handleMouse,
-    handleKeyUp,
-  ]);
+  }, [ref, disabled, handleKeyUp]);
 }
 
 export default useRootClose;

--- a/test/DropdownSpec.js
+++ b/test/DropdownSpec.js
@@ -350,6 +350,32 @@ describe('<Dropdown>', () => {
       document.activeElement.should.equal(root.getByText('Toggle'));
     });
 
+    it('when open and a search input is focused and the key "Escape" is pressed the menu stays open', () => {
+      const toggleSpy = sinon.spy();
+      const root = render(
+        <Dropdown defaultShow onToggle={toggleSpy}>
+          <Toggle key="toggle">Toggle</Toggle>,
+          <Menu key="menu">
+            <input type="search" data-testid="input" />
+          </Menu>
+        </Dropdown>,
+        {
+          container: focusableContainer,
+        },
+      );
+
+      const input = root.getByTestId('input');
+
+      input.focus();
+      document.activeElement.should.equal(input);
+
+      fireEvent.keyDown(input, { key: 'Escape' });
+
+      document.activeElement.should.equal(input);
+
+      toggleSpy.should.not.be.called;
+    });
+
     it('when open and the key "tab" is pressed the menu is closed and focus is progress to the next focusable element', () => {
       const root = render(
         <div>


### PR DESCRIPTION
- adds a new exception for the `escape` key close logic for search inputs, which use escape as the keyboard shortcut for clearing the value
- Add `useClickOutside` and use it in `useRootClose`
- replace useRootClose in dropdown menu with useClickOutside, we already handle the escape key logic in Dropdown
