### PR TITLE
chore(ci): bump node to v16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Node.js environment
         uses: actions/setup-node@v2
         with:
-          node-version: 12.x
+          node-version: 16.x
       - name: Update Brew (macOS)
         if: matrix.os == 'macOS-latest'
         run: brew update

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: 12.x
+          node-version: 16.x
       - name: Install Dependencies
         run: yarn bootstrap
       - name: Build and Deploy Production Files


### PR DESCRIPTION
Saw an error in the deploy docs github action.  Optional chaining is available in node version >= 14

```
 /home/runner/work/ui/ui/node_modules/hookem/lib.js:26
  const hooks = packageJson?.gitHooks || packageJson?.husky?.hooks;
                            ^

SyntaxError: Unexpected token '.'
    at wrapSafe (internal/modules/cjs/loader.js:915:16)
    at Module._compile (internal/modules/cjs/loader.js:963:27)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1027:10)
    at Module.load (internal/modules/cjs/loader.js:863:32)
    at Function.Module._load (internal/modules/cjs/loader.js:708:14)
    at Module.require (internal/modules/cjs/loader.js:887:19)
    at require (internal/modules/cjs/helpers.js:74:18)
    at Object.<anonymous> (/home/runner/work/ui/ui/node_modules/hookem/install.js:1:21)
    at Module._compile (internal/modules/cjs/loader.js:999:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1027:10)
```