### PR TITLE
fix(ModalManager): always get padding computed value

### DIFF
--- a/src/ModalManager.ts
+++ b/src/ModalManager.ts
@@ -76,14 +76,13 @@ class ModalManager {
       [paddingProp]: container.style[paddingProp],
     };
 
-    if (containerState.scrollBarWidth) {
-      // use computed style, here to get the real padding
-      // to add our scrollbar width
-      style[paddingProp] = `${
-        parseInt(css(container, paddingProp) || '0', 10) +
-        containerState.scrollBarWidth
-      }px`;
-    }
+    // use computed style, here to get the real padding
+    // to add our scrollbar width if present
+    style[paddingProp] = `${
+      parseInt(css(container, paddingProp) || '0', 10) +
+      (containerState.scrollBarWidth || 0)
+    }px`;
+
     container.setAttribute(OPEN_DATA_ATTRIBUTE, '');
 
     css(container, style as any);

--- a/test/ModalManagerSpec.ts
+++ b/test/ModalManagerSpec.ts
@@ -1,14 +1,16 @@
+import { expect } from 'chai';
 import css from 'dom-helpers/css';
 import getScrollbarSize from 'dom-helpers/scrollbarSize';
 
-import ModalManager from '../src/ModalManager';
+import ModalManager, { ModalInstance } from '../src/ModalManager';
 
 import { injectCss } from './helpers';
 
-const createModal = () => ({ dialog: null, backdrop: null });
+const createModal = () =>
+  ({ dialog: null, backdrop: null } as unknown as ModalInstance);
 
 describe('ModalManager', () => {
-  let container, manager;
+  let container: HTMLElement, manager: ModalManager;
 
   beforeEach(() => {
     manager?.reset();
@@ -21,19 +23,20 @@ describe('ModalManager', () => {
   afterEach(() => {
     manager?.reset();
     document.body.removeChild(container);
-    container = null;
-    manager = null;
+    container = null!;
+    manager = null!;
   });
 
   it('should add Modal', () => {
-    let modal = createModal();
+    const modal = createModal();
 
     manager.add(modal);
 
     expect(manager.modals.length).to.equal(1);
     expect(manager.modals[0]).to.equal(modal);
 
-    expect(manager.state).to.eql({
+    // eslint-disable-next-line dot-notation
+    expect(manager['state']).to.eql({
       scrollBarWidth: 0,
       style: {
         overflow: '',
@@ -43,7 +46,7 @@ describe('ModalManager', () => {
   });
 
   it('should not add a modal twice', () => {
-    let modal = createModal();
+    const modal = createModal();
     manager.add(modal);
     manager.add(modal);
 
@@ -51,8 +54,8 @@ describe('ModalManager', () => {
   });
 
   it('should add multiple modals', () => {
-    let modalA = createModal();
-    let modalB = createModal();
+    const modalA = createModal();
+    const modalB = createModal();
 
     manager.add(modalA);
     manager.add(modalB);
@@ -61,8 +64,8 @@ describe('ModalManager', () => {
   });
 
   it('should remove modal', () => {
-    let modalA = createModal();
-    let modalB = createModal();
+    const modalA = createModal();
+    const modalB = createModal();
 
     manager.add(modalA);
     manager.add(modalB);
@@ -90,7 +93,7 @@ describe('ModalManager', () => {
     afterEach(() => injectCss.reset());
 
     it('should set container overflow to hidden ', () => {
-      let modal = createModal();
+      const modal = createModal();
 
       expect(document.body.style.overflow).to.equal('');
 
@@ -100,7 +103,7 @@ describe('ModalManager', () => {
     });
 
     it('should respect handleContainerOverflow', () => {
-      let modal = createModal();
+      const modal = createModal();
 
       expect(document.body.style.overflow).to.equal('');
 
@@ -115,7 +118,7 @@ describe('ModalManager', () => {
     });
 
     it('should set add to existing container padding', () => {
-      let modal = createModal();
+      const modal = createModal();
       manager.add(modal);
 
       expect(document.body.style.paddingRight).to.equal(
@@ -124,7 +127,7 @@ describe('ModalManager', () => {
     });
 
     it('should set padding to left side if RTL', () => {
-      let modal = createModal();
+      const modal = createModal();
 
       new ModalManager({ isRTL: true }).add(modal);
 
@@ -134,7 +137,7 @@ describe('ModalManager', () => {
     });
 
     it('should restore container overflow style', () => {
-      let modal = createModal();
+      const modal = createModal();
 
       document.body.style.overflow = 'scroll';
 
@@ -148,7 +151,7 @@ describe('ModalManager', () => {
     });
 
     it('should reset overflow style to the computed one', () => {
-      let modal = createModal();
+      const modal = createModal();
 
       expect(css(document.body, 'overflow')).to.equal('scroll');
 
@@ -160,8 +163,8 @@ describe('ModalManager', () => {
     });
 
     it('should only remove styles when there are no associated modals', () => {
-      let modalA = createModal();
-      let modalB = createModal();
+      const modalA = createModal();
+      const modalB = createModal();
 
       expect(document.body.style.overflow).to.equal('');
 

--- a/test/helpers.tsx
+++ b/test/helpers.tsx
@@ -1,11 +1,11 @@
-export function shouldWarn(about) {
-  console.error.expected.push(about);
+export function shouldWarn(about: unknown) {
+  (console.error as any).expected.push(about);
 }
 
-let style;
-let seen = [];
+let style: HTMLStyleElement;
+let seen: string[] = [];
 
-export function injectCss(rules) {
+export function injectCss(rules: string) {
   if (seen.indexOf(rules) !== -1) {
     return;
   }
@@ -13,7 +13,7 @@ export function injectCss(rules) {
   style =
     style ||
     (function iife() {
-      let _style = document.createElement('style');
+      const _style = document.createElement('style');
       _style.appendChild(document.createTextNode(''));
       document.head.appendChild(_style);
       return _style;
@@ -27,6 +27,6 @@ injectCss.reset = () => {
   if (style) {
     document.head.removeChild(style);
   }
-  style = null;
+  style = null!;
   seen = [];
 };


### PR DESCRIPTION
### Fixes
- #48

### What's changed
Remove scrollbar width check before set style on container. 
This should make test works also on MacOS with automatic scrollbar display.
