### PR TITLE
feat(useClickOutside): ensure clicks are fully outside

### DIFF
--- a/src/useClickOutside.ts
+++ b/src/useClickOutside.ts
@@ -100,9 +100,9 @@ function useClickOutside(
     // https://github.com/facebook/react/issues/20074
     let currentEvent = (doc.defaultView || window).event;
 
-    let removeInitalTriggerListener: (() => void) | null = null;
+    let removeInitialTriggerListener: (() => void) | null = null;
     if (InitialTriggerEvents[clickTrigger]) {
-      removeInitalTriggerListener = listen(
+      removeInitialTriggerListener = listen(
         doc as any,
         InitialTriggerEvents[clickTrigger]!,
         handleInitialMouse,
@@ -137,12 +137,19 @@ function useClickOutside(
     }
 
     return () => {
-      removeInitalTriggerListener?.();
+      removeInitialTriggerListener?.();
       removeMouseCaptureListener();
       removeMouseListener();
       mobileSafariHackListeners.forEach((remove) => remove());
     };
-  }, [ref, disabled, clickTrigger, handleMouseCapture, handleMouse]);
+  }, [
+    ref,
+    disabled,
+    clickTrigger,
+    handleMouseCapture,
+    handleInitialMouse,
+    handleMouse,
+  ]);
 }
 
 export default useClickOutside;


### PR DESCRIPTION
Solves a pet peeve of mine where modal things close when you mouse/pointer up outside the element but starting inside it, e.g text selection where you drag past the menu.

I don't have a good idea how to write a test for this tbh