### PR TITLE
fix(TabPanel): move react-transition-group functions to metadata in hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "@types/mocha": "^8.2.3",
     "@types/react": "^17.0.3",
     "@types/react-dom": "^17.0.3",
+    "@types/react-transition-group": "^4.4.4",
     "@types/sinon": "^10.0.2",
     "@types/sinon-chai": "^3.2.5",
     "@typescript-eslint/eslint-plugin": "^4.22.0",

--- a/src/TabPanel.tsx
+++ b/src/TabPanel.tsx
@@ -61,23 +61,20 @@ export function useTabPanel({
   transition,
   unmountOnExit,
   role = 'tabpanel',
+  onEnter,
+  onEntering,
+  onEntered,
+  onExit,
+  onExiting,
+  onExited,
   ...props
 }: TabPanelProps): [any, TabPanelMetadata] {
   const context = useContext(TabContext);
-  const {
-    onEnter,
-    onEntering,
-    onEntered,
-    onExit,
-    onExiting,
-    onExited,
-    ...remainingProps
-  } = props;
 
   if (!context)
     return [
       {
-        ...remainingProps,
+        ...props,
         role,
       },
       {
@@ -100,7 +97,7 @@ export function useTabPanel({
 
   return [
     {
-      ...remainingProps,
+      ...props,
       role,
       id: getControlledId(eventKey!),
       'aria-labelledby': getControllerId(eventKey!),

--- a/src/TabPanel.tsx
+++ b/src/TabPanel.tsx
@@ -64,11 +64,20 @@ export function useTabPanel({
   ...props
 }: TabPanelProps): [any, TabPanelMetadata] {
   const context = useContext(TabContext);
+  const {
+    onEnter,
+    onEntering,
+    onEntered,
+    onExit,
+    onExiting,
+    onExited,
+    ...remainingProps
+  } = props;
 
   if (!context)
     return [
       {
-        ...props,
+        ...remainingProps,
         role,
       },
       {
@@ -77,6 +86,12 @@ export function useTabPanel({
         mountOnEnter,
         transition,
         unmountOnExit,
+        onEnter,
+        onEntering,
+        onEntered,
+        onExit,
+        onExiting,
+        onExited,
       },
     ];
 
@@ -85,7 +100,7 @@ export function useTabPanel({
 
   return [
     {
-      ...props,
+      ...remainingProps,
       role,
       id: getControlledId(eventKey!),
       'aria-labelledby': getControllerId(eventKey!),
@@ -99,6 +114,12 @@ export function useTabPanel({
       transition: transition || rest.transition,
       mountOnEnter: mountOnEnter != null ? mountOnEnter : rest.mountOnEnter,
       unmountOnExit: unmountOnExit != null ? unmountOnExit : rest.unmountOnExit,
+      onEnter,
+      onEntering,
+      onEntered,
+      onExit,
+      onExiting,
+      onExited,
     },
   ];
 }

--- a/test/TabPanelSpec.tsx
+++ b/test/TabPanelSpec.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { fireEvent, render, waitFor } from '@testing-library/react';
 import { expect } from 'chai';
 import sinon from 'sinon';
@@ -5,7 +6,6 @@ import Transition from 'react-transition-group/Transition';
 
 import TabContext from '../src/TabContext';
 import TabPanel, { useTabPanel } from '../src/TabPanel';
-import React from 'react';
 import { Button, Nav, Tabs, useNavItem } from '../src';
 
 describe('<TabPanel>', () => {

--- a/www/docs/Nav.mdx
+++ b/www/docs/Nav.mdx
@@ -160,6 +160,8 @@ when styled similarly.
 
 ```jsx live
 import clsx from "clsx";
+import Transition from "react-transition-group/Transition";
+import "../src/css/transitions.css";
 
 import {
   Button,
@@ -168,6 +170,24 @@ import {
   Nav,
   useNavItem,
 } from "@restart/ui";
+
+const FADE_DURATION = 200;
+
+const fadeStyles = {
+  entering: "show",
+  entered: "show",
+};
+
+const Fade = ({ children, ...props }) => (
+  <Transition {...props} timeout={FADE_DURATION}>
+    {(status, innerProps) =>
+      React.cloneElement(children, {
+        ...innerProps,
+        className: `fade ${fadeStyles[status]} ${children.props.className}`,
+      })
+    }
+  </Transition>
+);
 
 function Tab({ eventKey, ...props }) {
   const [navItemProps, meta] = useNavItem({
@@ -201,7 +221,11 @@ function Tab({ eventKey, ...props }) {
     <Tab eventKey="3">Three</Tab>
   </Nav>
   <div className="p-6">
-    <TabPanel eventKey="1">
+    <TabPanel
+      eventKey="1"
+      transition={Fade}
+      onEnter={() => console.log("onenee")}
+    >
       <p>one!</p>
     </TabPanel>
     <TabPanel eventKey="2">

--- a/www/docs/Nav.mdx
+++ b/www/docs/Nav.mdx
@@ -160,8 +160,6 @@ when styled similarly.
 
 ```jsx live
 import clsx from "clsx";
-import Transition from "react-transition-group/Transition";
-import "../src/css/transitions.css";
 
 import {
   Button,
@@ -170,24 +168,6 @@ import {
   Nav,
   useNavItem,
 } from "@restart/ui";
-
-const FADE_DURATION = 200;
-
-const fadeStyles = {
-  entering: "show",
-  entered: "show",
-};
-
-const Fade = ({ children, ...props }) => (
-  <Transition {...props} timeout={FADE_DURATION}>
-    {(status, innerProps) =>
-      React.cloneElement(children, {
-        ...innerProps,
-        className: `fade ${fadeStyles[status]} ${children.props.className}`,
-      })
-    }
-  </Transition>
-);
 
 function Tab({ eventKey, ...props }) {
   const [navItemProps, meta] = useNavItem({
@@ -221,11 +201,7 @@ function Tab({ eventKey, ...props }) {
     <Tab eventKey="3">Three</Tab>
   </Nav>
   <div className="p-6">
-    <TabPanel
-      eventKey="1"
-      transition={Fade}
-      onEnter={() => console.log("onenee")}
-    >
+    <TabPanel eventKey="1">
       <p>one!</p>
     </TabPanel>
     <TabPanel eventKey="2">

--- a/yarn.lock
+++ b/yarn.lock
@@ -1849,6 +1849,13 @@
   dependencies:
     "@types/react" "*"
 
+"@types/react-transition-group@^4.4.4":
+  version "4.4.4"
+  resolved "https://registry.yarnpkg.com/@types/react-transition-group/-/react-transition-group-4.4.4.tgz#acd4cceaa2be6b757db61ed7b432e103242d163e"
+  integrity sha512-7gAPz7anVK5xzbeQW9wFBDg7G++aPLAFY0QaSMOou9rJZpbuI58WAuJrgu+qR92l61grlnCUe7AFX8KGahAgug==
+  dependencies:
+    "@types/react" "*"
+
 "@types/react@*", "@types/react@>=16.9.11", "@types/react@^17.0.3":
   version "17.0.15"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.15.tgz#c7533dc38025677e312606502df7656a6ea626d0"


### PR DESCRIPTION
Followup to https://github.com/react-bootstrap/react-bootstrap/pull/6276. Essentially moves react-transition-group functions to `meta` in `useTabPanel` hook. Also added a test to make sure it works.

Had to add @types/react-transition-group since the tests are in typescript