### PR TITLE
fix(NavItem): inactive tabs should have aria-selected=“false”

### DIFF
--- a/src/NavItem.tsx
+++ b/src/NavItem.tsx
@@ -88,14 +88,15 @@ export function useNavItem({
   }
 
   if (props.role === 'tab') {
+    props['aria-selected'] = isActive;
+
+    if (!isActive) {
+      props.tabIndex = -1;
+    }
+
     if (disabled) {
       props.tabIndex = -1;
       props['aria-disabled'] = true;
-    }
-    if (isActive) {
-      props['aria-selected'] = isActive;
-    } else {
-      props.tabIndex = -1;
     }
   }
 

--- a/test/TabContainerSpec.tsx
+++ b/test/TabContainerSpec.tsx
@@ -132,10 +132,16 @@ describe('<Tabs>', () => {
     expect(getByText('Tab 1').getAttribute('aria-hidden')).to.equal('false');
     expect(getByText('Tab 2').getAttribute('aria-hidden')).to.equal('true');
 
+    expect(getByText('One').getAttribute('aria-selected')).to.equal('true');
+    expect(getByText('Two').getAttribute('aria-selected')).to.equal('false');
+
     fireEvent.click(getByText('Two'));
 
     expect(getByText('Tab 1').getAttribute('aria-hidden')).to.equal('true');
     expect(getByText('Tab 2').getAttribute('aria-hidden')).to.equal('false');
+
+    expect(getByText('One').getAttribute('aria-selected')).to.equal('false');
+    expect(getByText('Two').getAttribute('aria-selected')).to.equal('true');
   });
 
   it('Should mount and unmount tabs when set', () => {


### PR DESCRIPTION
The attribute `aria-selected` should always be present when using `role="tab"`.

> When elements with the tab role are selected or active they should have their [aria-selected](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-selected) attribute set to true. Otherwise, their `aria-selected` attribute should be set to false.

https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/tab_role#description