### PR TITLE
Document missing useLayoutEffect popper dependency

### DIFF
--- a/www/docs/Dropdown.mdx
+++ b/www/docs/Dropdown.mdx
@@ -30,6 +30,9 @@ const DropdownMenu = ({ role }) => {
 
   useLayoutEffect(() => {
     if (show) popper.update();
+    // useLayoutEffect must not depend on popper as this causes an endless loop
+    // because popper object changes on every render
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [show]);
 
   return (


### PR DESCRIPTION
DropdownMenu uses `useLayoutEffect` to update `popper`. If you want to make ESLint happy and add `popper` as a `useLayoutEffect` hook dependency this causes an endless loop because `popper` object changes on every render.

It makes sense to have this in the documentation because it is painful to debug why the app freezes when you toggle the menu.