### PR TITLE
Fix: forward eventListeners options to popper config

### DIFF
--- a/src/mergeOptionsWithPopperConfig.ts
+++ b/src/mergeOptionsWithPopperConfig.ts
@@ -57,6 +57,7 @@ export default function mergeOptionsWithPopperConfig({
       ...modifiers,
       eventListeners: {
         enabled: enableEvents,
+        options: modifiers.eventListeners?.options,
       },
       preventOverflow: {
         ...modifiers.preventOverflow,


### PR DESCRIPTION
I want to use tooltips from [React-Bootstrap](https://github.com/react-bootstrap/react-bootstrap) which wraps [Overlay](https://github.com/react-restart/ui/blob/main/src/Overlay.tsx) from this package, but, unfortunately, when I add `eventListeners` modifier with `{ scroll: false }` options object, it's not getting forwarded into Popper.js. This simple change fixes it.

