### PR TITLE
fix(Modal,Overlay): elements exit according to their transition

### DIFF
--- a/src/Modal.tsx
+++ b/src/Modal.tsx
@@ -274,7 +274,6 @@ const Modal: React.ForwardRefExoticComponent<
     const prevShow = usePrevious(show);
     const [exited, setExited] = useState(!show);
     const lastFocusRef = useRef<HTMLElement | null>(null);
-    const hasTransition = !!(transition || runTransition);
 
     useImperativeHandle(ref, () => modal, [modal]);
 
@@ -282,9 +281,8 @@ const Modal: React.ForwardRefExoticComponent<
       lastFocusRef.current = activeElement() as HTMLElement;
     }
 
-    if (!hasTransition && !show && !exited) {
-      setExited(true);
-    } else if (show && exited) {
+    // TODO: I think this needs to be in an effect
+    if (show && exited) {
       setExited(false);
     }
 
@@ -410,7 +408,7 @@ const Modal: React.ForwardRefExoticComponent<
       onExited?.(...args);
     };
 
-    if (!container || !(show || (hasTransition && !exited))) {
+    if (!container) {
       return null;
     }
 
@@ -435,6 +433,7 @@ const Modal: React.ForwardRefExoticComponent<
 
     dialog = renderTransition(transition, runTransition, {
       unmountOnExit: true,
+      mountOnEnter: true,
       appear: true,
       in: !!show,
       onExit,
@@ -459,6 +458,7 @@ const Modal: React.ForwardRefExoticComponent<
         {
           in: !!show,
           appear: true,
+          mountOnEnter: true,
           unmountOnExit: true,
           children: backdropElement as React.ReactElement,
         },

--- a/src/NoopTransition.tsx
+++ b/src/NoopTransition.tsx
@@ -1,25 +1,32 @@
-import { useEffect, useRef } from 'react';
+import useEventCallback from '@restart/hooks/useEventCallback';
+import useMergedRefs from '@restart/hooks/useMergedRefs';
+import { cloneElement, useEffect, useRef } from 'react';
 import { TransitionProps } from './types';
 
 function NoopTransition({
   children,
   in: inProp,
+  onExited,
   mountOnEnter,
   unmountOnExit,
 }: TransitionProps) {
+  const ref = useRef(null);
   const hasEnteredRef = useRef(inProp);
+  const handleExited = useEventCallback(onExited);
 
   useEffect(() => {
     if (inProp) hasEnteredRef.current = true;
-  }, [inProp]);
+    else {
+      handleExited(ref.current!);
+    }
+  }, [inProp, handleExited]);
 
-  if (inProp) return children;
+  const combinedRef = useMergedRefs(ref, (children as any).ref);
 
-  // not in
-  //
-  // if (!mountOnEnter && !unmountOnExit) {
-  //   return children;
-  // }
+  const child = cloneElement(children, { ref: combinedRef });
+
+  if (inProp) return child;
+
   if (unmountOnExit) {
     return null;
   }
@@ -27,7 +34,7 @@ function NoopTransition({
     return null;
   }
 
-  return children;
+  return child;
 }
 
 export default NoopTransition;

--- a/src/Overlay.tsx
+++ b/src/Overlay.tsx
@@ -149,8 +149,6 @@ const Overlay = React.forwardRef<HTMLElement, OverlayProps>(
 
     const [exited, setExited] = useState(!props.show);
 
-    const hasTransition = !!(Transition || runTransition);
-
     const popper = usePopper(
       target,
       rootElement,
@@ -165,10 +163,9 @@ const Overlay = React.forwardRef<HTMLElement, OverlayProps>(
       }),
     );
 
-    if (props.show) {
-      if (exited) setExited(false);
-    } else if (!hasTransition && !exited) {
-      setExited(true);
+    // TODO: I think this needs to be in an effect
+    if (props.show && exited) {
+      setExited(false);
     }
 
     const handleHidden: TransitionCallbacks['onExited'] = (...args) => {
@@ -180,7 +177,7 @@ const Overlay = React.forwardRef<HTMLElement, OverlayProps>(
     };
 
     // Don't un-render the overlay while it's transitioning out.
-    const mountOverlay = props.show || (hasTransition && !exited);
+    const mountOverlay = props.show || !exited;
 
     useRootClose(rootElement, props.onHide!, {
       disabled: !props.rootClose || props.rootCloseDisabled,
@@ -213,6 +210,9 @@ const Overlay = React.forwardRef<HTMLElement, OverlayProps>(
 
     child = renderTransition(Transition, runTransition, {
       in: !!props.show,
+      appear: true,
+      mountOnEnter: true,
+      unmountOnExit: true,
       children: child,
       onExit,
       onExiting,


### PR DESCRIPTION
This updates the Modal and Overlay components to exit more consistently according to their transitions. Previously the `Modal` would unmount as soon as it's dialog transition exited, even if the backdrop one had not finished. Originally i tried to exit when both were done, but actually that doesn't seem like the right behavior, bc you want each component to unmount as soon as it can. 

This also simplifies the logic a bit because we can leave the unmounting up to the consumer if they want to disregard our props. I also was able to remove the `!hasTransition` cases by using `NoopTransition`.