### PR TITLE
feat: add exports field in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,8 +11,21 @@
     "url": "git+https://github.com/react-restart/ui.git"
   },
   "license": "MIT",
-  "main": "lib/cjs/index.js",
-  "module": "lib/esm/index.js",
+  "main": "cjs/index.js",
+  "module": "esm/index.js",
+  "types": "esm/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./esm/index.d.ts",
+      "import": "./esm/index.js",
+      "require": "./cjs/index.js"
+    },
+    "./*": {
+      "types": "./esm/*.d.ts",
+      "import": "./esm/*.js",
+      "require": "./cjs/*.js"
+    }
+  },
   "sideEffects": false,
   "files": [
     "lib"


### PR DESCRIPTION
Same as https://github.com/react-restart/hooks/pull/88.  Need this to make TS work with module resolution `node16`