### PR TITLE
fix: prevent scrolling when focus trap cycles back into the modal

### DIFF
--- a/src/Modal.tsx
+++ b/src/Modal.tsx
@@ -5,9 +5,6 @@ import contains from 'dom-helpers/contains';
 import canUseDOM from 'dom-helpers/canUseDOM';
 import listen from 'dom-helpers/listen';
 
-import getScrollTop from 'dom-helpers/scrollTop';
-import getScrollLeft from 'dom-helpers/scrollLeft';
-
 import {
   useState,
   useRef,
@@ -279,7 +276,6 @@ const Modal: React.ForwardRefExoticComponent<
     const prevShow = usePrevious(show);
     const [exited, setExited] = useState(!show);
     const lastFocusRef = useRef<HTMLElement | null>(null);
-    const scrollPositionRef = useRef<any>(null);
 
     useImperativeHandle(ref, () => modal, [modal]);
 
@@ -294,11 +290,6 @@ const Modal: React.ForwardRefExoticComponent<
 
     const handleShow = useEventCallback(() => {
       modal.add();
-
-      scrollPositionRef.current = {
-        x: getScrollLeft(container!),
-        y: getScrollTop(container!),
-      };
 
       removeKeydownListenerRef.current = listen(
         document as any,

--- a/src/ModalManager.ts
+++ b/src/ModalManager.ts
@@ -1,4 +1,8 @@
 import css from 'dom-helpers/css';
+import getSetScrollTop from 'dom-helpers/scrollTop';
+import getSetScrollLeft from 'dom-helpers/scrollLeft';
+import getScrollParent from 'dom-helpers/scrollParent';
+import isDocument from 'dom-helpers/isDocument';
 import { dataAttr } from './DataKey';
 import getBodyScrollbarWidth from './getScrollbarWidth';
 
@@ -49,6 +53,11 @@ class ModalManager {
 
   getScrollbarWidth() {
     return getBodyScrollbarWidth(this.ownerDocument);
+  }
+
+  protected getScollingElement() {
+    const element = getScrollParent(this.getElement());
+    return isDocument(element) ? element.defaultView! : element;
   }
 
   getElement() {
@@ -113,8 +122,12 @@ class ModalManager {
       return modalIdx;
     }
 
+    const scrollElement = this.getScollingElement() as Element;
+
     this.state = {
       scrollBarWidth: this.getScrollbarWidth(),
+      scrollTop: getSetScrollTop(scrollElement),
+      scrollLeft: getSetScrollLeft(scrollElement),
       style: {},
     };
 
@@ -123,6 +136,19 @@ class ModalManager {
     }
 
     return modalIdx;
+  }
+
+  maybeResetScrollPosition() {
+    const scrollElement = this.getScollingElement() as Element;
+
+    const { scrollTop, scrollLeft } = this.state;
+
+    if (getSetScrollTop(scrollElement) !== scrollTop) {
+      getSetScrollTop(scrollElement, scrollTop);
+    }
+    if (getSetScrollLeft(scrollElement) !== scrollLeft) {
+      getSetScrollLeft(scrollElement, scrollLeft);
+    }
   }
 
   remove(modal: ModalInstance) {


### PR DESCRIPTION
also fixes a small issue with the `alertdialog` role fixing #81 and addresses the bug noted in https://github.com/react-bootstrap/react-bootstrap/issues/6579


I was hoping the scroll thing would be as simple as `preventDefault` on the incoming `focus` event but that doesn't seem to cut it in Chrome at least, so back to good ol manual scroll position setting.