### PR TITLE
fix(useRTGTransitionProps): only add transition callbacks if user passed

### DIFF
--- a/src/useRTGTransitionProps.ts
+++ b/src/useRTGTransitionProps.ts
@@ -60,13 +60,13 @@ export default function useRTGTransitionProps({
   return {
     ...props,
     nodeRef,
-    onEnter: handleEnter,
-    onEntering: handleEntering,
-    onEntered: handleEntered,
-    onExit: handleExit,
-    onExiting: handleExiting,
-    onExited: handleExited,
-    addEndListener: handleAddEndListener,
+    ...(onEnter && { onEnter: handleEnter }),
+    ...(onEntering && { onEntering: handleEntering }),
+    ...(onEntered && { onEntered: handleEntered }),
+    ...(onExit && { onExit: handleExit }),
+    ...(onExiting && { onExiting: handleExiting }),
+    ...(onExited && { onExited: handleExited }),
+    ...(addEndListener && { addEndListener: handleAddEndListener }),
     children:
       typeof children === 'function'
         ? (((status: TransitionStatus, innerProps: Record<string, unknown>) =>


### PR DESCRIPTION
Fixes https://github.com/react-bootstrap/react-bootstrap/issues/6778

This caused the issue over in RB because the props overrode the `addEndListener` prop that was passed into the transition.  The fix is to only add in the callbacks if user passed the callback into the transition