### PR TITLE
fix(useClickOutside): reset waitingForTrigger if clicking outside target

### DIFF
--- a/src/useClickOutside.ts
+++ b/src/useClickOutside.ts
@@ -82,6 +82,11 @@ function useClickOutside(
 
     if (currentTarget && contains(currentTarget, e.target as any)) {
       waitingForTrigger.current = true;
+    } else {
+      // When clicking on scrollbars within current target, click events are not triggered, so this ref
+      // is never reset inside `handleMouseCapture`. This would cause a bug where it requires 2 clicks
+      // to close the overlay.
+      waitingForTrigger.current = false;
     }
   });
 


### PR DESCRIPTION
Supercedes https://github.com/react-restart/ui/pull/111
Fixes https://github.com/react-bootstrap/react-bootstrap/issues/6836