### PR TITLE
fix: replace deprecated JSX global types

### DIFF
--- a/src/Button.tsx
+++ b/src/Button.tsx
@@ -13,7 +13,7 @@ export interface UseButtonPropsOptions extends AnchorOptions {
   disabled?: boolean;
   onClick?: React.EventHandler<React.MouseEvent | React.KeyboardEvent>;
   tabIndex?: number;
-  tagName?: keyof JSX.IntrinsicElements;
+  tagName?: keyof React.JSX.IntrinsicElements;
   role?: React.AriaRole | undefined;
 }
 
@@ -113,7 +113,7 @@ export interface BaseButtonProps {
    * Control the underlying rendered element directly by passing in a valid
    * component type
    */
-  as?: keyof JSX.IntrinsicElements | undefined;
+  as?: keyof React.JSX.IntrinsicElements | undefined;
 
   /** The disabled state of the button */
   disabled?: boolean | undefined;

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 export type EventKey = string | number;
 
-export type IntrinsicElementTypes = keyof JSX.IntrinsicElements;
+export type IntrinsicElementTypes = keyof React.JSX.IntrinsicElements;
 
 export type AssignPropsWithRef<
   Inner extends string | React.ComponentType<any>,


### PR DESCRIPTION
Fixes part of https://github.com/react-bootstrap/react-bootstrap/issues/6879