### PR TITLE
fix(Overlay): fix target type for react 19 refs

### DIFF
--- a/src/useWaitForDOMRef.ts
+++ b/src/useWaitForDOMRef.ts
@@ -5,7 +5,11 @@ import useWindow from './useWindow';
 import { VirtualElement } from './usePopper';
 
 export type DOMContainer<T extends HTMLElement | VirtualElement = HTMLElement> =
-  T | React.RefObject<T> | null | (() => T | React.RefObject<T> | null);
+
+    | T
+    | React.RefObject<T | null>
+    | null
+    | (() => T | React.RefObject<T | null> | null);
 
 export const resolveContainerRef = <T extends HTMLElement | VirtualElement>(
   ref: DOMContainer<T> | undefined,


### PR DESCRIPTION
Fixes an issue in react 19 where initial values are mandatory for refs and null was not allowed

Closes https://github.com/react-bootstrap/react-bootstrap/issues/6883

