### PR TITLE
fix: fix react 19 ref usage

### DIFF
--- a/src/ImperativeTransition.tsx
+++ b/src/ImperativeTransition.tsx
@@ -5,6 +5,7 @@ import React, { useRef, cloneElement, useState } from 'react';
 import { TransitionComponent, TransitionProps } from './types';
 import NoopTransition from './NoopTransition';
 import RTGTransition from './RTGTransition';
+import { getChildRef } from './utils';
 
 export interface TransitionFunctionOptions {
   in: boolean;
@@ -111,7 +112,7 @@ export default function ImperativeTransition({
     },
   });
 
-  const combinedRef = useMergedRefs(ref, (children as any).ref);
+  const combinedRef = useMergedRefs(ref, getChildRef(children));
 
   return exited && !inProp
     ? null

--- a/src/NoopTransition.tsx
+++ b/src/NoopTransition.tsx
@@ -2,6 +2,7 @@ import useEventCallback from '@restart/hooks/useEventCallback';
 import useMergedRefs from '@restart/hooks/useMergedRefs';
 import { cloneElement, useEffect, useRef } from 'react';
 import { TransitionProps } from './types';
+import { getChildRef } from './utils';
 
 function NoopTransition({
   children,
@@ -21,7 +22,7 @@ function NoopTransition({
     }
   }, [inProp, handleExited]);
 
-  const combinedRef = useMergedRefs(ref, (children as any).ref);
+  const combinedRef = useMergedRefs(ref, getChildRef(children));
 
   const child = cloneElement(children, { ref: combinedRef });
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -15,11 +15,12 @@ export function getReactVersion() {
 
 export function getChildRef(
   element?: React.ReactElement | ((...args: any[]) => React.ReactNode) | null,
-) {
+): React.Ref<any> | null {
   if (!element || typeof element === 'function') {
     return null;
   }
   const { major } = getReactVersion();
-  const childRef = major >= 19 ? element.props.ref : (element as any).ref;
+  const childRef =
+    major >= 19 ? (element.props as any).ref : (element as any).ref;
   return childRef;
 }


### PR DESCRIPTION
Fixes https://github.com/react-bootstrap/react-bootstrap/issues/6892

Backports changes from main to v1 branch to fix ref warnings