### PR TITLE
feat(Modal): add new render options for modal

### DIFF
--- a/src/ImperativeTransition.tsx
+++ b/src/ImperativeTransition.tsx
@@ -63,9 +63,6 @@ export function useTransition({
 
 export interface ImperativeTransitionProps extends TransitionProps {
   transition: TransitionHandler;
-  appear: true;
-  mountOnEnter: true;
-  unmountOnExit: true;
 }
 
 /**

--- a/src/ImperativeTransition.tsx
+++ b/src/ImperativeTransition.tsx
@@ -61,7 +61,8 @@ export function useTransition({
   return ref;
 }
 
-export interface ImperativeTransitionProps extends TransitionProps {
+export interface ImperativeTransitionProps
+  extends Omit<TransitionProps, 'appear' | 'mountOnEnter' | 'unmountOnExit'> {
   transition: TransitionHandler;
 }
 

--- a/test/ModalSpec.tsx
+++ b/test/ModalSpec.tsx
@@ -247,6 +247,31 @@ describe('<Modal>', () => {
     );
   });
 
+  it('should not render in a portal when `portal` is false', () => {
+    render(
+      <div data-testid="container">
+        <Modal show portal={false}>
+          <strong>Message</strong>
+        </Modal>
+      </div>,
+    );
+
+    expect(
+      screen.getByTestId('container').contains(screen.getByRole('dialog')),
+    ).toBeTruthy();
+  });
+
+  it('should render the dialog when mountDialogOnEnter and mountDialogOnEnter are false when not shown', () => {
+    render(
+      <Modal mountDialogOnEnter={false} unmountDialogOnExit={false}>
+        <strong>Message</strong>
+      </Modal>,
+      { container: attachTo },
+    );
+
+    expect(screen.getByText('Message')).toBeTruthy();
+  });
+
   describe('Focused state', () => {
     let focusableContainer: HTMLElement;
 


### PR DESCRIPTION
Adds new props to control the rendering of the modal.  I'm going to use this to fix the behavior of the offcanvas component in react-bootstrap to match upstream's behavior and better support the responsive use case.

`mountDialogOnEnter` - Whether or not the dialog is initially mounted in the DOM
`unmountDialogOnExit` - Whether or not the dialog element is unmounted when modal is hidden
`portal` - render using a portal or in place