### PR TITLE
fix: remove node from exports map

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,10 +18,6 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
-      "node": {
-        "types": "./cjs/index.d.ts",
-        "default": "./cjs/index.js"
-      },
       "require": {
         "types": "./cjs/index.d.ts",
         "default": "./cjs/index.js"
@@ -32,10 +28,6 @@
       }
     },
     "./*": {
-      "node": {
-        "types": "./cjs/*.d.ts",
-        "default": "./cjs/*.js"
-      },
       "require": {
         "types": "./cjs/*.d.ts",
         "default": "./cjs/*.js"

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -3,6 +3,8 @@
   "compilerOptions": {
     "jsx": "react-jsx",
     "lib": ["DOM", "ESNext"],
+    "moduleResolution": "bundler",
+    "module": "esnext",
     "rootDir": ".."
   },
   "include": ["../src", "."]


### PR DESCRIPTION
Don't think the node field in exports map is required anymore since this now supports proper ESM.  This is causing an issue in RB when consuming from an ESM perspective since types are resolving to the CJS variant.