### PR TITLE
fix: disable focus trap completely when `disabled` prop evaluates to `true`

### DIFF
--- a/src/useFocusTrap.tsx
+++ b/src/useFocusTrap.tsx
@@ -21,7 +21,7 @@ export function useFocusTrap({
   const handleKeydown = useEventCallback((event: KeyboardEvent) => {
     const container = getContainer();
 
-    if (event.key !== 'Tab' || !container) {
+    if (event.key !== 'Tab' || !container || disabled?.()) {
       return;
     }
 


### PR DESCRIPTION
Fixes an issue where `useFocusTrap` was still attempting to steal tab focus even when providing a `disabled` function that evaluated to `false`. The `disabled` function was only being checked when attempting to enforce focus.